### PR TITLE
Add SkillSwap docs

### DIFF
--- a/SkillSwap/COMMUNITY_FEATURES_AND_ENGAGEMENT.md
+++ b/SkillSwap/COMMUNITY_FEATURES_AND_ENGAGEMENT.md
@@ -1,0 +1,18 @@
+# Community & Gamification
+
+## Badges & Achievements
+- “First Swap” badge
+- “5-swap streak” achievement
+- “Community Champion” for top reviewers
+
+## Skill Challenges
+- Monthly themes (e.g., “Photography Month”)
+- Track progress on challenge dashboard
+
+## Event Board
+- Create/join local study groups
+- RSVP + calendar integration
+
+## Partnerships
+- Sandbox API for schools/libraries
+- Co-hosted community workshops

--- a/SkillSwap/DEV_TIMELINE_AND_TASK_BOARD.md
+++ b/SkillSwap/DEV_TIMELINE_AND_TASK_BOARD.md
@@ -1,0 +1,45 @@
+# 12-Week Roadmap (2–3 Devs)
+
+weeks:
+  - w1:
+      - setup: repo + CI/CD
+      - design: UX wireframes
+  - w2:
+      - auth: signup/login flows
+      - db: schema migrations
+  - w3:
+      - matching engine prototype
+      - basic UI: onboarding
+  - w4:
+      - swap flow + chat integration
+      - unit tests: core modules
+  - w5:
+      - feedback system
+      - rating UI + API
+  - w6:
+      - point wallet + ledger service
+      - e2e tests: swaps
+  - w7:
+      - safety features (email verify, report)
+      - admin panel MVP
+  - w8:
+      - community board + badges
+      - challenge module backend
+  - w9:
+      - premium filters + subscription API
+      - billing integration
+  - w10:
+      - mobile web polish
+      - performance tuning
+  - w11:
+      - partner integration plan
+      - staging deployment
+  - w12:
+      - final QA + load tests
+      - production launch
+
+# Task Assignments
+dev1:
+  - auth, DB schema, matching engine, billing
+dev2:
+  - UI flows, chat integration, feedback, community

--- a/SkillSwap/FEEDBACK_AND_TRUST_SYSTEM.md
+++ b/SkillSwap/FEEDBACK_AND_TRUST_SYSTEM.md
@@ -1,0 +1,20 @@
+# Feedback & Trust System
+
+## Rated Metrics
+- Skill quality (1–5)
+- Reliability (1–5)
+- Communication (1–5)
+
+## Written Reviews
+- Optional text field (max 500 chars)
+- Displayed on user profile with date stamp.
+
+## Trust Score Calculation
+```
+trust_score = (avg_skill + avg_reliability + avg_comm) / 3
+```
+- Decay factor: older reviews weight ↓10%/month.
+
+## Moderation Flags
+- >3 consecutive 1-star reviews → auto-flag.
+- Admin approval required before profile removal.

--- a/SkillSwap/MATCHING_ENGINE_SPEC.md
+++ b/SkillSwap/MATCHING_ENGINE_SPEC.md
@@ -1,0 +1,25 @@
+# Matching Engine Spec
+
+## Matching Pairs & Chains
+- **Pair**: Match A\u21C4B if skills intersect and availability overlaps.
+- **Chain**: A\u2192B\u2192C\u2192A for triangular swaps when direct match absent.
+
+## Constraints
+- **Time window**: \u00b130 min tolerance.
+- **Location**: radius filter or virtual flag.
+
+## Barter Logic
+- **1hr:1hr** by default.
+- **Point system**: 1 credit = 1 min; supports fractional trades.
+- **Fairness check**: total credits on both sides \u22645% variance.
+
+### Pseudocode
+```python
+def find_matches(user):
+    candidates = query_users(skill=user.desired, avail=user.avail)
+    for c in candidates:
+        if hours_match(user, c):
+            yield Pair(user, c)
+    if no_pair:
+        yield from find_chains(user)
+```

--- a/SkillSwap/MONETIZATION_AND_SCALING_PLAN.md
+++ b/SkillSwap/MONETIZATION_AND_SCALING_PLAN.md
@@ -1,0 +1,20 @@
+# Monetization & Scaling
+
+## Premium Features
+- Advanced filters (e.g., skill level, verified tutors)
+- Ad-free experience
+- Priority matching (faster queue)
+
+## Subscription Tiers
+- **Free**: basic matching + chat
+- **Pro ($5/mo)**: premium filters + unlimited history
+- **Org ($50/mo)**: group management, event stats
+
+## Partnerships
+- Sponsored community events
+- Co-branding with local orgs
+
+## Regional Expansion
+1. Pilot city → refine model
+2. Franchise partnerships → local ownership
+3. Full rollout in 3 regions by Q4

--- a/SkillSwap/MVP-FEATURES-LIST.md
+++ b/SkillSwap/MVP-FEATURES-LIST.md
@@ -1,0 +1,29 @@
+# SkillSwap MVP Feature Breakdown
+
+## Must-Have
+1. **User Onboarding & Profile**
+   - Personal bio, skill tags, availability calendar
+   - Justification: Core identity and scheduling
+2. **Swap Matching**
+   - Hour-for-hour or point-equivalent algorithm
+   - Justification: Fundamental exchange engine
+3. **In-App Chat**
+   - Real-time messaging + swap negotiation
+   - Justification: Coordination and trust
+4. **Feedback & Ratings**
+   - Star/point ratings, comments
+   - Justification: Quality assurance
+
+## Should-Have
+5. **Skill Challenge Module**
+   - Monthly themed objectives
+   - Tech scope: frontend React, backend task scheduler
+6. **Point Wallet**
+   - Track earned/spent credits
+   - Tech scope: simple ledger microservice
+
+## Could-Have
+7. **Local Event Board**
+   - Group swap listings, forums
+8. **Badge System**
+   - Gamified milestones for completed swaps

--- a/SkillSwap/SAFETY_PROTOCOL_AND_GUARDRAILS.md
+++ b/SkillSwap/SAFETY_PROTOCOL_AND_GUARDRAILS.md
@@ -1,0 +1,19 @@
+# Safety Protocol & Guardrails
+
+## MVP Safety Features
+- Email verification & 2FA
+- Profile photo upload (face match check)
+- Report button on swap and chat
+
+## Moderation Workflow
+1. **Auto-flag**: profanity or spam triggers.
+2. **Human review**: flagged items appear in admin queue.
+3. **Action**: warning → suspension → ban.
+
+## Scalability
+- **Machine learning**: NLP filter for toxic content.
+- **Tiered review**: community moderators + paid team.
+
+## UX Integration
+- Safety tips banner on chat screen.
+- At-swap confirmation: “Review safety guidelines.”

--- a/SkillSwap/SKILLSWAP-VISION-SUMMARY.md
+++ b/SkillSwap/SKILLSWAP-VISION-SUMMARY.md
@@ -1,0 +1,19 @@
+# SkillSwap
+
+## Mission
+SkillSwap empowers communities to share skills without money, breaking down economic barriers and fostering social connection.
+
+## Social Issues Addressed
+- **Economic inequality**: Provides free access to learning for under-resourced members.
+- **Social isolation**: Builds local networks through one-on-one skill exchanges.
+- **Access disparity**: Enables peer-to-peer tutoring where formal classes aren’t available.
+
+## What Makes Us Different
+- **Barter-first**: Hour-for-hour exchanges (or point-backed swaps) instead of monetary transactions.
+- **Local + Virtual**: Seamless hybrid matching for in-person or online skill trades.
+- **Community-owned**: Users vote on new features and local partnerships.
+
+## Long-Term Vision
+- **Skill trees**: Gamified progression maps your growth and encourages challenges.
+- **Institutional partnerships**: Co-hosted workshops with schools and libraries.
+- **Global network**: Connect regions, share best practices, and spotlight social impact metrics.

--- a/SkillSwap/TECH_STACK_AND_SCHEMA.md
+++ b/SkillSwap/TECH_STACK_AND_SCHEMA.md
@@ -1,0 +1,55 @@
+# Tech Stack & API
+
+backend:
+  framework: Node.js + Express
+  db: MongoDB (Atlas)
+  auth: Firebase Auth (email+OAuth)
+  messaging: Socket.io
+
+frontend:
+  framework: React Native (iOS/Android) + React Web
+  styling: Tailwind CSS
+
+---
+
+# API Endpoints
+
+- `POST /api/signup`
+- `POST /api/login`
+- `GET  /api/users/:id/matches`
+- `POST /api/swaps`
+- `GET  /api/swaps/:id/messages`
+- `POST /api/swaps/:id/feedback`
+
+---
+
+# Database Schema
+
+users:
+  - _id: ObjectId
+  - name: String
+  - skills: [String]
+  - avail: [{ day, start, end }]
+  - reputation: Number
+
+swaps:
+  - _id: ObjectId
+  - participants: [ObjectId]
+  - type: enum{PAIR,CHAIN}
+  - start: Date
+  - end: Date
+  - status: enum{PENDING,CONFIRMED,COMPLETED}
+
+messages:
+  - _id: ObjectId
+  - swapId: ObjectId
+  - sender: ObjectId
+  - text: String
+  - timestamp: Date
+
+feedback:
+  - _id: ObjectId
+  - swapId: ObjectId
+  - rater: ObjectId
+  - rating: Number
+  - comment: String

--- a/SkillSwap/UI_FLOW_AND_WIREFRAME_PLAN.md
+++ b/SkillSwap/UI_FLOW_AND_WIREFRAME_PLAN.md
@@ -1,0 +1,28 @@
+# UI Flow & Wireframe Plan
+
+## 1. Onboarding Screen
+- **Goal**: Collect bio, skills, availability.
+- **Wireframe**: Multi-step form with progress bar.
+- **Accessibility**: Large tap targets, easy keyboard nav.
+
+## 2. Dashboard
+- **Goal**: Show pending matches, upcoming swaps, earned credits.
+- **Wireframe**: Card list + calendar peek.
+- **Notes**: Color-blind friendly palette.
+
+## 3. Matching Screen
+- **Goal**: Browse potential matches by skill and proximity.
+- **Wireframe**: Filter sidebar + map/list toggle.
+
+## 4. Swap Detail & Chat
+- **Goal**: Review partner’s profile, confirm swap time, chat.
+- **Wireframe**: Split view: details above, chat thread below.
+
+## 5. Feedback Screen
+- **Goal**: Rate completed swap.
+- **Wireframe**: Star selector + comment field.
+
+> Wireframes can be delivered as JSON objects for tools like Figma API:
+> ```json
+> { "screen": "Dashboard", "elements": [ ... ] }
+> ```


### PR DESCRIPTION
## Summary
- create `SkillSwap` folder with documentation for the SkillSwap project

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mailchimp_marketing')*

------
https://chatgpt.com/codex/tasks/task_e_684713f9c9688329a36e0911bbb89a36