### PR TITLE
Add trade logging CLI with tests

### DIFF
--- a/trading_system_optimizer/cli.py
+++ b/trading_system_optimizer/cli.py
@@ -1,0 +1,33 @@
+import argparse
+import sys
+from pathlib import Path
+
+# Allow running as a script without installing the package
+if __package__ is None or __package__ == "":
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from trading_system_optimizer.journal.trade_entry import TradeEntry
+from trading_system_optimizer.journal import journal_manager
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Log a trade via CLI")
+    parser.add_argument("ticker", help="Ticker symbol")
+    parser.add_argument("entry", type=float, help="Entry price")
+    parser.add_argument("--exit", type=float, help="Exit price", default=None)
+    parser.add_argument("--notes", help="Trade notes", default="")
+    parser.add_argument(
+        "--log-path",
+        type=str,
+        default=str(journal_manager.TRADE_LOG_PATH),
+        help="Path to YAML log file",
+    )
+    args = parser.parse_args(argv)
+
+    entry = TradeEntry(ticker=args.ticker, entry=args.entry, exit=args.exit, notes=args.notes)
+    journal_manager.append_entry(entry, Path(args.log_path))
+    print("Trade logged:", entry.to_dict())
+
+
+if __name__ == "__main__":
+    main()

--- a/trading_system_optimizer/tests/test_cli.py
+++ b/trading_system_optimizer/tests/test_cli.py
@@ -1,0 +1,22 @@
+import subprocess
+from pathlib import Path
+
+
+def test_cli_logs_trade(tmp_path):
+    log_file = tmp_path / "log.yaml"
+    cli_script = Path(__file__).resolve().parent.parent / "cli.py"
+    subprocess.check_call([
+        "python",
+        str(cli_script),
+        "AAPL",
+        "100",
+        "--exit",
+        "110",
+        "--notes",
+        "test",
+        "--log-path",
+        str(log_file),
+    ])
+    assert log_file.exists()
+    data = log_file.read_text()
+    assert "AAPL" in data


### PR DESCRIPTION
## Summary
- add a small CLI tool for Trading System Optimizer to log trades to YAML
- allow specifying log path via `--log-path`
- test the CLI and pass through all existing unit tests

## Testing
- `pytest Forges/VlogForge/tests/test_content_manager.py Forges/VlogForge/tests/test_engagement_tracker.py Wizards/AI_Architect/tests/test_api.py Wizards/AI_Architect/tests/test_code_generator.py Wizards/AI_Architect/tests/test_project_manager.py Wizards/api_wizard_project/tests/test_api_wizard.py trading_system_optimizer/tests/test_cli.py tests/test_tasks_json.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686115d334f88329a96636109a234954